### PR TITLE
improve the parser and tests

### DIFF
--- a/HLTrigger/HLTcore/interface/TriggerExpressionL1uGTReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionL1uGTReader.h
@@ -10,7 +10,7 @@ namespace triggerExpression {
 
   class L1uGTReader : public Evaluator {
   public:
-    L1uGTReader(const std::string& pattern) : m_pattern(pattern), m_triggers() {}
+    L1uGTReader(const std::string& pattern) : m_pattern{pattern}, m_triggers{}, m_initialised{false} {}
 
     bool operator()(const Data& data) const override;
 
@@ -20,7 +20,8 @@ namespace triggerExpression {
 
   private:
     std::string m_pattern;
-    std::vector<std::pair<std::string, unsigned int> > m_triggers;
+    std::vector<std::pair<std::string, unsigned int>> m_triggers;
+    bool m_initialised;
   };
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
@@ -55,8 +55,10 @@ namespace triggerExpression {
     bool operator()(const Data& data) const override { return not(*m_arg)(data); }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       out << "NOT ";
       m_arg->dump(out);
+      out << ')';
     }
   };
 
@@ -72,9 +74,11 @@ namespace triggerExpression {
     }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       m_arg1->dump(out);
       out << " AND ";
       m_arg2->dump(out);
+      out << ')';
     }
   };
 
@@ -90,9 +94,11 @@ namespace triggerExpression {
     }
 
     void dump(std::ostream& out) const override {
+      out << '(';
       m_arg1->dump(out);
       out << " OR ";
       m_arg2->dump(out);
+      out << ')';
     }
   };
 

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -23,11 +23,22 @@ namespace triggerExpression {
   class Parser : public qi::grammar<Iterator, Evaluator *(), ascii::space_type> {
   public:
     Parser() : Parser::base_type(expression) {
+      auto delimiter = qi::copy(qi::eoi | !qi::char_("a-zA-Z0-9_*?"));
+
+      token_true = qi::lexeme[qi::lit("TRUE") >> delimiter];
+      token_false = qi::lexeme[qi::lit("FALSE") >> delimiter];
+
+      operand_not = qi::lexeme[qi::lit("NOT") >> delimiter];
+      operand_and = qi::lexeme[qi::lit("AND") >> delimiter];
+      operand_or = qi::lexeme[qi::lit("OR") >> delimiter];
+
       token_l1algo %= qi::raw[qi::lexeme["L1_" >> +(qi::char_("a-zA-Z0-9_*?"))]];
       token_path %= qi::raw[qi::lexeme[+(qi::char_("a-zA-Z0-9_*?"))]];
 
-      token = (qi::lit("TRUE")[qi::_val = new_<Constant>(true)] | qi::lit("FALSE")[qi::_val = new_<Constant>(false)] |
-               token_l1algo[qi::_val = new_<L1uGTReader>(qi::_1)] | token_path[qi::_val = new_<PathReader>(qi::_1)]);
+      token = (token_true[qi::_val = new_<Constant>(true)] |         // TRUE
+               token_false[qi::_val = new_<Constant>(false)] |       // FALSE
+               token_l1algo[qi::_val = new_<L1uGTReader>(qi::_1)] |  // L1_*
+               token_path[qi::_val = new_<PathReader>(qi::_1)]);     // *
 
       parenthesis %= ('(' >> expression >> ')');
 
@@ -37,16 +48,24 @@ namespace triggerExpression {
 
       operand %= (prescale | element);
 
-      unary = ((qi::lit("NOT") >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
+      unary = ((operand_not >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
 
       expression =
-          unary[qi::_val = qi::_1] >> *((qi::lit("AND") >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |
-                                        (qi::lit("OR") >> unary)[qi::_val = new_<OperatorOr>(qi::_val, qi::_1)]);
+          unary[qi::_val = qi::_1] >> *((operand_and >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |
+                                        (operand_or >> unary)[qi::_val = new_<OperatorOr>(qi::_val, qi::_1)]);
     }
 
   private:
     typedef qi::rule<Iterator, std::string(), ascii::space_type> name_rule;
     typedef qi::rule<Iterator, Evaluator *(), ascii::space_type> rule;
+    typedef qi::rule<Iterator> terminal_rule;
+
+    terminal_rule token_true;
+    terminal_rule token_false;
+
+    terminal_rule operand_not;
+    terminal_rule operand_and;
+    terminal_rule operand_or;
 
     name_rule token_l1algo;
     name_rule token_path;

--- a/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionParser.h
@@ -48,7 +48,8 @@ namespace triggerExpression {
 
       operand %= (prescale | element);
 
-      unary = ((operand_not >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
+      unary = *(operand_not >> operand_not) >>
+              ((operand_not >> operand)[qi::_val = new_<OperatorNot>(qi::_1)] | operand[qi::_val = qi::_1]);
 
       expression =
           unary[qi::_val = qi::_1] >> *((operand_and >> unary)[qi::_val = new_<OperatorAnd>(qi::_val, qi::_1)] |

--- a/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
@@ -10,7 +10,7 @@ namespace triggerExpression {
 
   class PathReader : public Evaluator {
   public:
-    PathReader(const std::string& pattern) : m_pattern(pattern), m_triggers() {}
+    PathReader(const std::string& pattern) : m_pattern{pattern}, m_triggers{}, m_initialised{false} {}
 
     bool operator()(const Data& data) const override;
 
@@ -22,7 +22,8 @@ namespace triggerExpression {
 
   private:
     std::string m_pattern;
-    std::vector<std::pair<std::string, unsigned int> > m_triggers;
+    std::vector<std::pair<std::string, unsigned int>> m_triggers;
+    bool m_initialised;
   };
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionL1uGTReader.cc
@@ -28,6 +28,10 @@ namespace triggerExpression {
   }
 
   void L1uGTReader::dump(std::ostream& out) const {
+    if (not m_initialised) {
+      out << "Uninitialised_L1_Expression";
+      return;
+    }
     if (m_triggers.empty()) {
       out << "FALSE";
     } else if (m_triggers.size() == 1) {
@@ -85,6 +89,8 @@ namespace triggerExpression {
               << "requested pattern \"" << m_pattern << "\" does not match any L1 trigger in the current menu";
       }
     }
+
+    m_initialised = true;
   }
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
@@ -22,6 +22,10 @@ namespace triggerExpression {
   }
 
   void PathReader::dump(std::ostream& out) const {
+    if (not m_initialised) {
+      out << "Uninitialised_Path_Expression";
+      return;
+    }
     if (m_triggers.empty()) {
       out << "FALSE";
     } else if (m_triggers.size() == 1) {
@@ -84,6 +88,8 @@ namespace triggerExpression {
         }
       }
     }
+
+    m_initialised = true;
   }
 
 }  // namespace triggerExpression

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -16,7 +16,10 @@ namespace {
       return false;
     }
 
-    edm::LogPrint("testExpression") << "Parsed expression: \"" << expression << "\"";
+    std::ostringstream out;
+    expr->dump(out);
+    edm::LogPrint("testExpression") << "Parsed expression: \"" << expression << "\"\n               as: \"" << out.str()
+                                    << '"';
     return true;
   }
 

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -52,6 +52,9 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
                            "((Uninitialised_Path_Expression AND TRUE) AND (NOT Uninitialised_L1_Expression))"));
     REQUIRE(testExpression("NOT NOTThisHLTPath",  //
                            "(NOT Uninitialised_Path_Expression)"));
+    REQUIRE(testExpression(
+        "NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)",  //
+        "((Uninitialised_Path_Expression AND Uninitialised_L1_Expression) OR Uninitialised_Path_Expression)"));
     REQUIRE(testExpression("ThisHLTANDNOTThatORTheOther",  //
                            "Uninitialised_Path_Expression"));
     REQUIRE(testExpression("TRUEPath AND NOTPath",  //
@@ -80,7 +83,6 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(not testExpression("A && B"));
     REQUIRE(not testExpression("NOT L1_SEED1 ANDD L1_SEED2*"));
     REQUIRE(not testExpression("NOT (NOTHLT_Path OR HLT_Path2))"));
-    REQUIRE(not testExpression("NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)"));
     REQUIRE(not testExpression("HLT_Path* NOT TRUE"));
     REQUIRE(not testExpression("ThisPath ANDThatPath"));
   }

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -35,6 +35,7 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(testExpression("NOTThisHLTPath AND TRUE AND NOT L1_A?_*"));
     REQUIRE(testExpression("NOT NOTThisHLTPath"));
     REQUIRE(testExpression("ThisHLTANDNOTThatORTheOther"));
+    REQUIRE(testExpression("TRUEPath AND NOTPath"));
     REQUIRE(testExpression("NOT L1_SEED1 AND L1_SEED2*"));
     REQUIRE(testExpression("NOT L1_SEED2 AND (HLT_PATH_? AND NOT HLT_PATH2_??_*)"));
     REQUIRE(testExpression("NOT (HLT_Path1 AND HLT_Path2)"));
@@ -51,5 +52,6 @@ TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
     REQUIRE(not testExpression("NOT (NOTHLT_Path OR HLT_Path2))"));
     REQUIRE(not testExpression("NOT NOT (HLT_Path1 AND L1_Seed_?? OR HLT_Path_*)"));
     REQUIRE(not testExpression("HLT_Path* NOT TRUE"));
+    REQUIRE(not testExpression("ThisPath ANDThatPath"));
   }
 }

--- a/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_TriggerExpressionParser.cc
@@ -7,8 +7,9 @@
 #include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
 
 namespace {
+  using namespace std::literals;
 
-  bool testExpression(std::string const& expression) {
+  bool testExpression(std::string const& expression, std::string const& expected = {}) {
     auto const* expr = triggerExpression::parse(expression);
 
     if (not expr) {
@@ -18,8 +19,19 @@ namespace {
 
     std::ostringstream out;
     expr->dump(out);
-    edm::LogPrint("testExpression") << "Parsed expression: \"" << expression << "\"\n               as: \"" << out.str()
-                                    << '"';
+    std::string const& str = out.str();
+
+    if (not expected.empty() and str != expected) {
+      edm::LogWarning("InvalidInput")                         //
+          << "Parsed expression: \"" << expression << "\"\n"  //
+          << "as:                \"" << str << "\"\n"         //
+          << "instead of:        \"" << expected << '"';
+      return false;
+    }
+
+    edm::LogPrint("testExpression")                         //
+        << "Parsed expression: \"" << expression << "\"\n"  //
+        << "as:                \"" << str << '"';
     return true;
   }
 
@@ -28,20 +40,38 @@ namespace {
 TEST_CASE("Test TriggerExpressionParser", "[TriggerExpressionParser]") {
   // examples of expressions supported by the triggerExpression parser
   SECTION("CorrectExpressions") {
-    REQUIRE(testExpression("TRUE"));
-    REQUIRE(testExpression("FALSE"));
-    REQUIRE(testExpression("NOT (FALSE)"));
-    REQUIRE(testExpression("(NOT FALSE) OR TRUE"));
-    REQUIRE(testExpression("NOTThisHLTPath AND TRUE AND NOT L1_A?_*"));
-    REQUIRE(testExpression("NOT NOTThisHLTPath"));
-    REQUIRE(testExpression("ThisHLTANDNOTThatORTheOther"));
-    REQUIRE(testExpression("TRUEPath AND NOTPath"));
-    REQUIRE(testExpression("NOT L1_SEED1 AND L1_SEED2*"));
-    REQUIRE(testExpression("NOT L1_SEED2 AND (HLT_PATH_? AND NOT HLT_PATH2_??_*)"));
-    REQUIRE(testExpression("NOT (HLT_Path1 AND HLT_Path2)"));
-    REQUIRE(testExpression("NOT (NOTHLT_Path OR HLT_Path2)"));
-    REQUIRE(testExpression("((L1_A AND HLT_B) OR Dataset_C) AND NOT (Status_D OR Name_E OR HLT_F*) AND L1_??_?_?"));
-    REQUIRE(testExpression("NOT (NOT (HLT_Path1 AND HLT_Path_*))"));
+    REQUIRE(testExpression("TRUE",  //
+                           "TRUE"));
+    REQUIRE(testExpression("FALSE",  //
+                           "FALSE"));
+    REQUIRE(testExpression("NOT (FALSE)",  //
+                           "(NOT FALSE)"));
+    REQUIRE(testExpression("(NOT FALSE) OR TRUE",  //
+                           "((NOT FALSE) OR TRUE)"));
+    REQUIRE(testExpression("NOTThisHLTPath AND TRUE AND NOT L1_A?_*",
+                           "((Uninitialised_Path_Expression AND TRUE) AND (NOT Uninitialised_L1_Expression))"));
+    REQUIRE(testExpression("NOT NOTThisHLTPath",  //
+                           "(NOT Uninitialised_Path_Expression)"));
+    REQUIRE(testExpression("ThisHLTANDNOTThatORTheOther",  //
+                           "Uninitialised_Path_Expression"));
+    REQUIRE(testExpression("TRUEPath AND NOTPath",  //
+                           "(Uninitialised_Path_Expression AND Uninitialised_Path_Expression)"));
+    REQUIRE(testExpression("NOT L1_SEED1 AND L1_SEED2*",  //
+                           "((NOT Uninitialised_L1_Expression) AND Uninitialised_L1_Expression)"));
+    REQUIRE(testExpression("NOT L1_SEED2 AND (HLT_PATH_? AND NOT HLT_PATH2_??_*)",  //
+                           "((NOT Uninitialised_L1_Expression) AND (Uninitialised_Path_Expression AND (NOT "
+                           "Uninitialised_Path_Expression)))"));
+    REQUIRE(testExpression("NOT (HLT_Path1 AND HLT_Path2)",  //
+                           "(NOT (Uninitialised_Path_Expression AND Uninitialised_Path_Expression))"));
+    REQUIRE(testExpression("NOT (NOTHLT_Path OR HLT_Path2)",  //
+                           "(NOT (Uninitialised_Path_Expression OR Uninitialised_Path_Expression))"));
+    REQUIRE(testExpression(
+        "((L1_A AND HLT_B) OR Dataset_C) AND NOT (Status_D OR Name_E OR HLT_F*) AND L1_??_?_?",  //
+        "((((Uninitialised_L1_Expression AND Uninitialised_Path_Expression) OR Uninitialised_Path_Expression)"
+        " AND (NOT ((Uninitialised_Path_Expression OR Uninitialised_Path_Expression)"
+        " OR Uninitialised_Path_Expression))) AND Uninitialised_L1_Expression)"));
+    REQUIRE(testExpression("NOT (NOT (HLT_Path1 AND HLT_Path_*))",  //
+                           "(NOT (NOT (Uninitialised_Path_Expression AND Uninitialised_Path_Expression)))"));
   }
 
   // examples of expressions not supported by the triggerExpression parser


### PR DESCRIPTION
TriggerExpression parsers:
  - improve the representation of trigger expression
  - delimit tokens and operands

Unit test:
  - print how the expressions are interpreted
  - compare the parsed representation with the expected one
  - add more tests