### PR TITLE
[DO NOT MERGE] Fixing race conditions in PF-clustering kernels

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
@@ -3508,6 +3508,32 @@ namespace PFClusterCudaHCAL {
     } while (notDone);
   }
 
+  // pfrh_parent: RecHit index -> first parent
+  // pfrh_parent_new (after this kernel): RecHit index -> oldest parent in the chain
+  __global__ void contractRecHitParentArray(size_t size, int* pfrh_parent, int* pfrh_parent_new) {
+    auto const thread = threadIdx.x + blockIdx.x * blockDim.x;
+    auto const stride = blockDim.x * gridDim.x;
+
+    for (auto idx = thread; idx < size; idx += stride) {
+      int parent = pfrh_parent[idx];
+      while (parent >= 0 and parent != pfrh_parent[parent]) {
+        parent = pfrh_parent[parent];
+      }
+      pfrh_parent_new[idx] = parent;
+    }
+  }
+
+  // copies foo[idx] to bar[idx], and sets foo[idx] to val
+  __global__ void arrayCopyAndReset(size_t size, int* foo, int* bar, int val) {
+    auto const thread = threadIdx.x + blockIdx.x * blockDim.x;
+    auto const stride = blockDim.x * gridDim.x;
+
+    for (auto idx = thread; idx < size; idx += stride) {
+      bar[idx] = foo[idx];
+      foo[idx] = val;
+    }
+  }
+
   // Contraction in a single block
   __global__ void topoClusterContraction(size_t size,
                                          int* pfrh_parent,
@@ -3521,35 +3547,22 @@ namespace PFClusterCudaHCAL {
                                          int* pcrhfracind,
                                          float* pcrhfrac,
                                          int* pcrhFracSize) {
-    __shared__ int notDone, totalSeedOffset, totalSeedFracOffset;
+    __shared__ int totalSeedOffset, totalSeedFracOffset;
+
+    assert(gridDim.x == 1);
+
+    auto const thread = threadIdx.x + blockIdx.x * blockDim.x;
+    auto const stride = blockDim.x * gridDim.x;
+
     if (threadIdx.x == 0) {
-      notDone = 0;
       totalSeedOffset = 0;
       totalSeedFracOffset = 0;
       *pcrhFracSize = 0;
     }
     __syncthreads();
 
-    do {
-      volatile bool threadNotDone = false;
-      for (int i = threadIdx.x; i < size; i += blockDim.x) {
-        int parent = pfrh_parent[i];
-        if (parent >= 0 && parent != pfrh_parent[parent]) {
-          threadNotDone = true;
-          pfrh_parent[i] = pfrh_parent[parent];
-        }
-      }
-      if (threadIdx.x == 0)
-        notDone = 0;
-      __syncthreads();
-
-      atomicAdd(&notDone, (int)threadNotDone);
-      __syncthreads();
-
-    } while (notDone);
-
     // Now determine the number of seeds and rechits in each topo cluster
-    for (int rhIdx = threadIdx.x; rhIdx < size; rhIdx += blockDim.x) {
+    for (int rhIdx = thread; rhIdx < size; rhIdx += stride) {
       int topoId = pfrh_parent[rhIdx];
       if (topoId > -1) {
         // Valid topo cluster
@@ -3562,7 +3575,7 @@ namespace PFClusterCudaHCAL {
     __syncthreads();
 
     // Determine offsets for topo ID seed array
-    for (int topoId = threadIdx.x; topoId < size; topoId += blockDim.x) {
+    for (int topoId = thread; topoId < size; topoId += stride) {
       if (topoSeedCount[topoId] > 0) {
         // This is a valid topo ID
         int offset = atomicAdd(&totalSeedOffset, topoSeedCount[topoId]);
@@ -3572,7 +3585,7 @@ namespace PFClusterCudaHCAL {
     __syncthreads();
 
     // Fill arrays of seed indicies per topo ID
-    for (int rhIdx = threadIdx.x; rhIdx < size; rhIdx += blockDim.x) {
+    for (int rhIdx = thread; rhIdx < size; rhIdx += stride) {
       int topoId = pfrh_parent[rhIdx];
       if (topoId > -1 && pfrh_isSeed[rhIdx]) {
         // Valid topo cluster
@@ -3583,7 +3596,7 @@ namespace PFClusterCudaHCAL {
     __syncthreads();
 
     // Determine seed offsets for rechit fraction array
-    for (int rhIdx = threadIdx.x; rhIdx < size; rhIdx += blockDim.x) {
+    for (int rhIdx = thread; rhIdx < size; rhIdx += stride) {
       rhCount[rhIdx] = 1;  // Reset this counter array
 
       int topoId = pfrh_parent[rhIdx];
@@ -3598,6 +3611,7 @@ namespace PFClusterCudaHCAL {
       }
     }
     __syncthreads();
+
     if (threadIdx.x == 0) {
       *pcrhFracSize = totalSeedFracOffset;
       //printf("At the end of topoClusterContraction, found *pcrhFracSize = %d\n", *pcrhFracSize);
@@ -4495,6 +4509,19 @@ namespace PFClusterCudaHCAL {
                                                   outputGPU.pfrh_passTopoThresh.get(),
                                                   outputGPU.topoIter.get());
     cudaCheck(cudaStreamSynchronize(cudaStream));
+
+    auto const threadsPerBlock = 256;
+    auto const numBlocks = (nRH + threadsPerBlock - 1) / threadsPerBlock;
+
+    // find the oldest grandparent of every RecHit, and
+    // save this information temporarily in the array scratchGPU.rhcount
+    contractRecHitParentArray<<<numBlocks, threadsPerBlock, 0, cudaStream>>>
+      (nRH, outputGPU.pfrh_topoId.get(), scratchGPU.rhcount.get());
+
+    // copy the oldest-grandparent array to outputGPU.pfrh_topoId, and
+    // re-initialise all elements of scratchGPU.rhcount to 0
+    arrayCopyAndReset<<<numBlocks, threadsPerBlock, 0, cudaStream>>>
+      (nRH, scratchGPU.rhcount.get(), outputGPU.pfrh_topoId.get(), 0);
 
     topoClusterContraction<<<1, 512, 0, cudaStream>>>(nRH,
                                                       outputGPU.pfrh_topoId.get(),

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
@@ -3749,9 +3749,12 @@ namespace PFClusterCudaHCAL {
     }
 
     do {
+      __syncthreads();
+
       if (threadIdx.x == 0) {
         notDone = false;
       }
+
       __syncthreads();
 
       // Odd linking
@@ -3787,6 +3790,8 @@ namespace PFClusterCudaHCAL {
 
       if (!notDone)
         break;
+
+      __syncthreads();
 
       if (threadIdx.x == 0) {
         notDone = false;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCudaHCAL.cu
@@ -4438,24 +4438,24 @@ namespace PFClusterCudaHCAL {
     cudaEventRecord(start, cudaStream);
 #endif
 
-    //    prepareTopoInputsSerial<<<1, 1, 4 * (8+4) * sizeof(int), cudaStream>>>(
-    //        nRH,
-    //        outputGPU.nEdges.get(),
-    //        outputGPU.pfrh_passTopoThresh.get(),
-    //        inputPFRecHits.pfrh_neighbours.get(),
-    //        scratchGPU.pfrh_edgeId.get(),
-    //        scratchGPU.pfrh_edgeList.get());
+    prepareTopoInputsSerial<<<1, 1, 4 * (8+4) * sizeof(int), cudaStream>>>(
+        nRH,
+        outputGPU.nEdges.get(),
+        outputGPU.pfrh_passTopoThresh.get(),
+        inputPFRecHits.pfrh_neighbours.get(),
+        scratchGPU.pfrh_edgeId.get(),
+        scratchGPU.pfrh_edgeList.get());
 
-    // Topo clustering
-    // Fill edgeId, edgeList arrays with rechit neighbors
-    // Has a bug when using more than 128 threads..
-    prepareTopoInputs<<<1, 128, 128 * (8 + 4) * sizeof(int), cudaStream>>>(nRH,
-                                                                           outputGPU.nEdges.get(),
-                                                                           outputGPU.pfrh_passTopoThresh.get(),
-                                                                           inputPFRecHits.pfrh_neighbours.get(),
-                                                                           scratchGPU.pfrh_edgeId.get(),
-                                                                           scratchGPU.pfrh_edgeList.get());
-    cudaCheck(cudaStreamSynchronize(cudaStream));
+//    // Topo clustering
+//    // Fill edgeId, edgeList arrays with rechit neighbors
+//    // Has a bug when using more than 128 threads..
+//    prepareTopoInputs<<<1, 128, 128 * (8 + 4) * sizeof(int), cudaStream>>>(nRH,
+//                                                                           outputGPU.nEdges.get(),
+//                                                                           outputGPU.pfrh_passTopoThresh.get(),
+//                                                                           inputPFRecHits.pfrh_neighbours.get(),
+//                                                                           scratchGPU.pfrh_edgeId.get(),
+//                                                                           scratchGPU.pfrh_edgeList.get());
+//    cudaCheck(cudaStreamSynchronize(cudaStream));
 
     //    prepareTopoInputs<<<1, 256, 256 * (8+4) * sizeof(int), cudaStream>>>(
     //        nRH,


### PR DESCRIPTION
This PR contains some small updates related to the first CUDA implementation of the PF-clustering algorithm.

This PR is only for illustration purposes. The reason is that I'm not sure anymore what the latest stable branch is, and whether or not that already includes fixes/changes for the points discussed here.

The base of this PR is representative of the code we were using towards the end of Patatrack-11 ([report](https://indico.cern.ch/event/1147719/timetable/#79-final-scrum)).

The PR itself shows simple ways to get around the race conditions found in the GPU PF-clusteriser during the hackathon.

These race conditions are the likely culprits of the issue observed back then of jobs getting stuck with multiple threads (or, "high enough" throughput); during the hackathon, I hadn't managed to work around this problem.

This PR does not contain elegant long-term solutions, just minimal shortcuts (all this is improvable).

With these shortcuts, `compute-sanitizer --tool racecheck cmsRun cfg.py` returns 0 errors on O(10) MC events. A config file for testing is attached: [devel_pfOnGPU_fixRaceCond_cfg.py](https://github.com/missirol/cmssw/files/9767479/devel_pfOnGPU_fixRaceCond_cfg.py.txt).

Since all this is still new to me, any suggestions are welcomed.

FYI: @hatakeyamak @fwyzard @felicepantaleo

---

It might be easier to review the 3 commits individually. Some details follow.

* 4cb2a020af1 : use `prepareTopoInputsSerial` to avoid race condition in `scan1Inclusive`
  There is a race condition in `prepareTopoInputs` (the parallel version), which comes from the function `scan1Inclusive` (this was already pointed out by Andrea during the hackathon). From [the available documentation (slide 14)](https://indico.cern.ch/event/1136419/contributions/4768347/attachments/2403336/4110604/PF_HLT_GPU_Mar7_2022.pdf), I grasp that the general idea behind the use of `scan1Inclusive` is to do a "prefix scan". If so, this should probably be done with the implementation already available in CMSSW ([`prefixScan.h`](https://github.com/cms-sw/cmssw/blob/018b8bc5f74c66e6fff3764572c498bed19cc130/HeterogeneousCore/CUDAUtilities/interface/prefixScan.h)), getting rid of `scan1Inclusive` et al., but I didn't figure out the exact way to do it. The shortcut is to use the 'serial' version of the routine, i.e. `prepareTopoInputsSerial`.

* 9d9f31d7e75 : fix of race condition in `topoClusterLinking`
  This race condition originates from the use of `notDone` as a shared variable. The minimal workaround is to add `__syncthreads` calls to ensure that `notDone` is not updated by any thread before it is evaluated (e.g. adding a synchronisation between `if(not notDone) break;` and `notDone = false`).
  It looks like the only reason to have `notDone` as a shared variable is to increment the `iter` counter, but the latter is only used "for debugging purposes". I think one could (1) get rid of the `iter` counter, (2) make `notDone` non-shared, and (3) remove a good number of `__syncthreads` calls in the kernel.

* a000edd8218 : avoid race-condition in `topoClusterContraction`
  This another case of a race condition related to a shared variable `notDone`. This piece of code is meant to update the array of `RecHit -> Parent RecHit` to return the oldest grandparent (parent of the parent of the..) instead of the first parent. In this case, I tried a different approach: I moved the update of the parent-array to a separate kernel. One advantage is that this sub-kernel alone can now run on many blocks, b/c it does not have the restriction of running on only 1 block (which the whole `topoClusterContraction` has). One disadvantage was that I had to use one of the GPU scratch arrays to copy the new values back and forth.

Physics outputs were checked (i.e. the PFlow DQM module still considers the CPU and GPU outputs compatible), on 1000 TTbar events.

Timing of the relevant producers looks similar after the PR (only judged from `FastTimerService` report on O(100) MC events).